### PR TITLE
Fixed typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import algosdk from 'algosdk'
 // import { AlgoSignerSession } from './wallets/algosigner'
 try {
     // @ts-ignore
-    const account = algosdk.generateAccounts()
+    const account = algosdk.generateAccount()
     console.log(`Generated Algorand account: ${account.addr}`)
     document.getElementById('status').innerHTML = 'SDK Status: Working!'
 } catch(e) {


### PR DESCRIPTION
The site was defaulting to an error state because `algosdk.generateAccount()` had a typo with an "s" at the end.